### PR TITLE
修复了在群内艾特机器人发送指令显示未绑定uid的问题

### DIFF
--- a/apps/hkrpg.js
+++ b/apps/hkrpg.js
@@ -84,7 +84,7 @@ export class hkrpg extends plugin {
   async note (e) {
     let user = this.e.sender.user_id
     let ats = e.message.filter(m => m.type === 'at')
-    if (ats.length > 0) {
+    if (ats.length > 0 && !e.atBot) {
       user = ats[0].qq
     }
     let uid = await redis.get(`STAR_RAILWAY:UID:${user}`)
@@ -122,7 +122,8 @@ export class hkrpg extends plugin {
   async month (e) {
     let user = this.e.sender.user_id
     let ats = e.message.filter(m => m.type === 'at')
-    if (ats.length > 0) {
+    
+    > 0) {
       user = ats[0].qq
     }
     let uid = await redis.get(`STAR_RAILWAY:UID:${user}`)
@@ -152,7 +153,7 @@ export class hkrpg extends plugin {
     if (!uid) {
       let user = this.e.sender.user_id
       let ats = e.message.filter(m => m.type === 'at')
-      if (ats.length > 0) {
+      if (ats.length > 0 && !e.atBot) {
         user = ats[0].qq
       }
       uid = await redis.get(`STAR_RAILWAY:UID:${user}`)
@@ -232,7 +233,7 @@ export class hkrpg extends plugin {
     }
     let user = this.e.sender.user_id
     let ats = e.message.filter(m => m.type === 'at')
-    if (ats.length > 0) {
+    if (ats.length > 0 && !e.atBot) {
       user = ats[0].qq
     }
     let authKey = await redis.get(`STAR_RAILWAY:AUTH_KEY:${user}`)


### PR DESCRIPTION
修复了在群内艾特机器人发送指令显示未绑定uid的问题，刚刚没改全（dog）