### PR TITLE
修复在某些环境下会报fetch is not defined的问题

### DIFF
--- a/utils/authkey.js
+++ b/utils/authkey.js
@@ -1,4 +1,5 @@
 // import User from "../../xiaoyao-cvs-plugin/model/user.js";
+import fetch from 'node-fetch'
 import MysSRApi from '../runtime/MysSRApi.js'
 let User
 try {


### PR DESCRIPTION
修复某些环境下由于未定义fetch导致即使安装了逍遥插件扫码依旧提示请先安装逍遥插件再扫码登陆。