### PR TITLE
Fix: 艾特群友的时候正常显示卡片

### DIFF
--- a/apps/hkrpg.js
+++ b/apps/hkrpg.js
@@ -57,6 +57,7 @@ export class Hkrpg extends plugin {
       let ats = e.message.filter(m => m.type === 'at')
       if (ats.length > 0 && !e.atBot) {
         user = ats[0].qq
+        e.user_id = user
       }
       let hasPersonalCK = false
       let uid = e.msg.match(/\d+/)?.[0]


### PR DESCRIPTION
Fix issue #120 

参考 `rogue.js` 中的 `rogue` 和 `rogue_locust` 方法，但是不能把那两行直接搬过来（会报错）

暂时没有 fix 到别的 at 功能上，怕有一些奇奇怪怪的权限问题