### PR TITLE
Fix: 当上半挑战成功或放弃，但是下半未开始挑战时，模板渲染直接失败

### DIFF
--- a/resources/challenge/index.html
+++ b/resources/challenge/index.html
@@ -129,7 +129,7 @@
                 {{ /each }}
               </div>
               <div class="detail-buff">
-                {{ if 'buff' in floor.node_1 }}
+                {{ if floor.node_1?.buff }}
                   <div class="detail-buff-border">
                     <div class="buff-col">
                       <div class="buff-icon-container">
@@ -177,7 +177,7 @@
                 {{ /each }}
               </div>
               <div class="detail-buff">
-                {{ if 'buff' in floor.node_2 }}
+                {{ if floor.node_2?.buff }}
                   <div class="detail-buff-border">
                     <div class="buff-col">
                       <div class="buff-icon-container">


### PR DESCRIPTION
此时下半的 `buff` 取值可能为 `null`